### PR TITLE
Fix possible IllegalArgumentException: Health must be between 0 and 20.0

### DIFF
--- a/src/main/java/com/mengcraft/playersql/task/CheckLoadedTask.java
+++ b/src/main/java/com/mengcraft/playersql/task/CheckLoadedTask.java
@@ -48,7 +48,10 @@ public class CheckLoadedTask implements Runnable {
 	private void sync(Player player, JsonArray value) {
 		// TODO maybe need caching configure
 		if (this.plugin.getConfig().getBoolean("sync.health")) {
-			player.setHealth(value.get(0).getAsDouble());
+			double health = value.get(0).getAsDouble();
+			if(health > 20)
+				health = 20;
+			player.setHealth(health);
 		}
 		if (this.plugin.getConfig().getBoolean("sync.food")) {
 			player.setFoodLevel(value.get(1).getAsInt());


### PR DESCRIPTION
We had trouble with a Denizen script setting the players health higher than 20 so I think this fix is a good idea to prevent players from losing their inventories in such cases.