### PR TITLE
Player field length too short for UUID!

### DIFF
--- a/src/main/java/com/mengcraft/playersql/Main.java
+++ b/src/main/java/com/mengcraft/playersql/Main.java
@@ -54,7 +54,7 @@ public class Main extends JavaPlugin {
             Connection connection = handler.getConnection();
             String sql = "CREATE TABLE IF NOT EXISTS PlayerData("
                     + "`Id` int NOT NULL AUTO_INCREMENT, "
-                    + "`Player` varchar(16) NULL, " // player nicknames are limited to 16 characters
+                    + "`Player` char(36) NULL, "
                     + "`Data` text NULL, "
                     + "`Online` int NULL, "
                     + "`Last` bigint NULL, "


### PR DESCRIPTION
UUID is always 36 chars long, varchar is unnecessary!
In my opinion the simplest table with best performance should generate as this:

CREATE TABLE `PlayerData` (
  `Player` char(36) NOT NULL DEFAULT '',
  `Data` text,
  `Online` tinyint(1) DEFAULT NULL,
  `Last` bigint(20) DEFAULT NULL,
  PRIMARY KEY (`Player`)
);