### PR TITLE
Block more event if inventory isn't synced up.

### DIFF
--- a/src/main/java/com/mengcraft/playersql/Events.java
+++ b/src/main/java/com/mengcraft/playersql/Events.java
@@ -114,6 +114,30 @@ public class Events implements Listener {
     	}
     }
 
+    @EventHandler
+    public void handle(PlayerInteractAtEntityEvent event) {
+        UUID uuid = e.getPlayer().getUniqueId();
+        if (compond.state(uuid) != null) {
+            e.setCancelled(true);
+        }
+    }
+    
+    @EventHandler
+    public void handle(PlayerInteractEntityEvent event) {
+        UUID uuid = e.getPlayer().getUniqueId();
+        if (compond.state(uuid) != null) {
+            e.setCancelled(true);
+        }
+    }
+
+    @EventHandler
+    public void handle(PlayerCommandPreprocessEvent event) {
+        UUID uuid = e.getPlayer().getUniqueId();
+        if (compond.state(uuid) != null) {
+            e.setCancelled(true);
+        }
+    }
+
     public void register() {
         main.getServer().getPluginManager().registerEvents(this, main);
     }


### PR DESCRIPTION
I'v blocked more event while inventory isn't synced : 

Block event PlayerCommandPreprocessEvent (Interrupt ALL command)
Block event PlayerInteractEntityEvent (Interrupt interaction with ItemFrame)
Block event PlayerInteractAtEntityEvent (Interrupt interaction with ArmorStand)